### PR TITLE
feat: Implement Java Spring Boot foundation for Confluence MCP Server

### DIFF
--- a/MIGRATION_ARCHITECTURE.md
+++ b/MIGRATION_ARCHITECTURE.md
@@ -1,0 +1,131 @@
+# Confluence MCP Server Migration Architecture
+
+## Current State (TypeScript) vs Target State (Java Spring Boot)
+
+```mermaid
+graph TB
+    subgraph "TypeScript MCP Server (Source)"
+        TS_CLI["CLI Interface<br/>atlassian.*.cli.ts"]
+        TS_TOOLS["MCP Tools<br/>atlassian.*.tool.ts"]
+        TS_CONTROLLERS["Controllers<br/>atlassian.*.controller.ts"]
+        TS_SERVICES["Services<br/>vendor.atlassian.*.service.ts"]
+        TS_UTILS["Utils<br/>config, logger, transport, etc."]
+        TS_TYPES["Types<br/>*.types.ts"]
+        
+        TS_CLI --> TS_CONTROLLERS
+        TS_TOOLS --> TS_CONTROLLERS
+        TS_CONTROLLERS --> TS_SERVICES
+        TS_SERVICES --> TS_UTILS
+        TS_CONTROLLERS --> TS_UTILS
+        TS_TOOLS --> TS_TYPES
+        TS_CONTROLLERS --> TS_TYPES
+        TS_SERVICES --> TS_TYPES
+    end
+    
+    subgraph "Java Spring Boot MCP Server (Target)"
+        JAVA_APP["@SpringBootApplication<br/>ConfluenceMcpSvrApplication"]
+        JAVA_TOOLS["MCP Tools<br/>@Tool annotations"]
+        JAVA_SERVICES["@Service Components<br/>Business Logic"]
+        JAVA_CLIENTS["API Clients<br/>WebClient/RestTemplate"]
+        JAVA_CONFIG["@Configuration<br/>Properties & Beans"]
+        JAVA_MODELS["POJOs<br/>Records & DTOs"]
+        JAVA_UTILS["Utility Classes<br/>Static methods"]
+        JAVA_EXCEPTIONS["Custom Exceptions<br/>@ControllerAdvice"]
+        
+        JAVA_APP --> JAVA_TOOLS
+        JAVA_TOOLS --> JAVA_SERVICES
+        JAVA_SERVICES --> JAVA_CLIENTS
+        JAVA_SERVICES --> JAVA_UTILS
+        JAVA_CLIENTS --> JAVA_CONFIG
+        JAVA_TOOLS --> JAVA_MODELS
+        JAVA_SERVICES --> JAVA_MODELS
+        JAVA_CLIENTS --> JAVA_MODELS
+        JAVA_SERVICES --> JAVA_EXCEPTIONS
+    end
+    
+    subgraph "External Dependencies"
+        CONFLUENCE_API["Confluence REST API v2"]
+        MCP_PROTOCOL["MCP JSON-RPC Protocol"]
+    end
+    
+    TS_SERVICES --> CONFLUENCE_API
+    TS_TOOLS --> MCP_PROTOCOL
+    
+    JAVA_CLIENTS --> CONFLUENCE_API
+    JAVA_TOOLS --> MCP_PROTOCOL
+    
+    subgraph "Migration Mapping"
+        direction TB
+        MAP1["TypeScript Types → Java Records/POJOs"]
+        MAP2["Vendor Services → API Clients + @Service"]
+        MAP3["Controllers → @Service Components"]
+        MAP4["Tools → @Tool Methods"]
+        MAP5["Utils → Utility Classes + @Configuration"]
+    end
+```
+
+## Feature Modules
+
+### 1. Pages Module
+**TypeScript Components:**
+- `vendor.atlassian.pages.service.ts` → API client
+- `atlassian.pages.controller.ts` → Business logic
+- `atlassian.pages.tool.ts` → MCP tools
+- `atlassian.pages.types.ts` → Data models
+
+**Java Components:**
+- `ConfluencePagesClient` → API integration
+- `ConfluencePagesService` → Business logic
+- `PagesToolsConfiguration` → MCP tool definitions
+- `Page`, `PageDetails`, `PagesResponse` → Data models
+
+### 2. Search Module
+**TypeScript Components:**
+- `vendor.atlassian.search.service.ts` → API client
+- `atlassian.search.controller.ts` → Business logic
+- `atlassian.search.tool.ts` → MCP tools
+- `atlassian.search.types.ts` → Data models
+
+**Java Components:**
+- `ConfluenceSearchClient` → API integration
+- `ConfluenceSearchService` → Business logic
+- `SearchToolsConfiguration` → MCP tool definitions
+- `SearchRequest`, `SearchResult` → Data models
+
+### 3. Spaces Module
+**TypeScript Components:**
+- `vendor.atlassian.spaces.service.ts` → API client
+- `atlassian.spaces.controller.ts` → Business logic
+- `atlassian.spaces.tool.ts` → MCP tools
+- `atlassian.spaces.types.ts` → Data models
+
+**Java Components:**
+- `ConfluenceSpacesClient` → API integration
+- `ConfluenceSpacesService` → Business logic
+- `SpacesToolsConfiguration` → MCP tool definitions
+- `Space`, `SpaceDetails` → Data models
+
+## Configuration Strategy
+
+**TypeScript (Current):**
+- Environment variables via dotenv
+- Global config file at `~/.mcp/configs.json`
+- Runtime config loading
+
+**Java (Target):**
+- Spring Boot application.properties
+- Environment variable binding with @Value
+- @ConfigurationProperties for structured config
+- Profile-based configuration
+
+## Key Technology Mappings
+
+| TypeScript | Java Spring Boot |
+|------------|------------------|
+| @modelcontextprotocol/sdk | Spring AI MCP Server WebMVC |
+| node-fetch | WebClient / RestTemplate |
+| dotenv | @ConfigurationProperties |
+| commander (CLI) | Spring Boot CommandLineRunner |
+| jest | JUnit 5 + Mockito |
+| turndown (HTML→MD) | CommonMark or similar |
+| zod validation | Jakarta Validation |

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(23)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
@@ -22,9 +22,42 @@ ext {
 }
 
 dependencies {
+	// Spring Boot core dependencies
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+	
+	// Spring AI MCP Server
 	implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webmvc'
+	
+	// HTTP Client for Confluence API
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	
+	// JSON processing
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	
+	// Utilities
+	implementation 'org.apache.commons:commons-lang3:3.18.0'
+	implementation 'org.apache.commons:commons-text:1.11.0'
+	
+	// Markdown processing (for HTML to Markdown conversion)
+	implementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
+	
+	// Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+	
+	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'io.projectreactor:reactor-test'
+	testImplementation 'org.mockito:mockito-core'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
+	testImplementation 'org.wiremock:wiremock-standalone:3.3.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluencePagesClient.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluencePagesClient.java
@@ -1,0 +1,145 @@
+package io.github.greenstevester.confluence_mcp_svr.client;
+
+import io.github.greenstevester.confluence_mcp_svr.model.common.PaginatedResponse;
+import io.github.greenstevester.confluence_mcp_svr.model.dto.GetPageRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.dto.ListPagesRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.page.Page;
+import io.github.greenstevester.confluence_mcp_svr.model.page.PageDetailed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.stream.Collectors;
+
+/**
+ * Client for interacting with Confluence Pages API
+ */
+@Component
+public class ConfluencePagesClient {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluencePagesClient.class);
+    private static final String API_PATH = "/wiki/api/v2";
+    
+    private final WebClient webClient;
+    
+    public ConfluencePagesClient(WebClient confluenceWebClient) {
+        this.webClient = confluenceWebClient;
+    }
+    
+    /**
+     * List pages from Confluence
+     */
+    public Mono<PaginatedResponse<Page>> listPages(ListPagesRequest request) {
+        logger.debug("Listing pages with request: {}", request);
+        
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        
+        if (request.id() != null && !request.id().isEmpty()) {
+            queryParams.put("id", request.id());
+        }
+        if (request.spaceId() != null && !request.spaceId().isEmpty()) {
+            queryParams.put("space-id", request.spaceId());
+        }
+        if (request.parentId() != null) {
+            queryParams.add("parent-id", request.parentId());
+        }
+        if (request.sort() != null) {
+            queryParams.add("sort", request.sort().getValue());
+        }
+        if (request.status() != null && !request.status().isEmpty()) {
+            String statusValues = request.status().stream()
+                .map(status -> status.getValue())
+                .collect(Collectors.joining(","));
+            queryParams.add("status", statusValues);
+        }
+        if (request.title() != null) {
+            queryParams.add("title", request.title());
+        }
+        if (request.bodyFormat() != null) {
+            queryParams.add("body-format", request.bodyFormat().getValue());
+        }
+        if (request.cursor() != null) {
+            queryParams.add("cursor", request.cursor());
+        }
+        if (request.limit() != null) {
+            queryParams.add("limit", request.limit().toString());
+        }
+        
+        String uri = UriComponentsBuilder.fromPath(API_PATH + "/pages")
+            .queryParams(queryParams)
+            .toUriString();
+            
+        logger.debug("Making request to: {}", uri);
+        
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<PaginatedResponse<Page>>() {})
+            .doOnSuccess(response -> logger.debug("Successfully retrieved {} pages", 
+                response != null ? response.results().size() : 0))
+            .doOnError(error -> logger.error("Error listing pages", error));
+    }
+    
+    /**
+     * Get a specific page by ID
+     */
+    public Mono<PageDetailed> getPage(String pageId, GetPageRequest request) {
+        logger.debug("Getting page {} with request: {}", pageId, request);
+        
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        
+        if (request.bodyFormat() != null) {
+            queryParams.add("body-format", request.bodyFormat().getValue());
+        }
+        if (request.getDraft() != null) {
+            queryParams.add("get-draft", request.getDraft().toString());
+        }
+        if (request.status() != null && !request.status().isEmpty()) {
+            String statusValues = request.status().stream()
+                .map(status -> status.getValue())
+                .collect(Collectors.joining(","));
+            queryParams.add("status", statusValues);
+        }
+        if (request.version() != null) {
+            queryParams.add("version", request.version().toString());
+        }
+        if (request.includeLabels() != null) {
+            queryParams.add("include-labels", request.includeLabels().toString());
+        }
+        if (request.includeProperties() != null) {
+            queryParams.add("include-properties", request.includeProperties().toString());
+        }
+        if (request.includeVersions() != null) {
+            queryParams.add("include-versions", request.includeVersions().toString());
+        }
+        if (request.includeVersion() != null) {
+            queryParams.add("include-version", request.includeVersion().toString());
+        }
+        if (request.includeWebresources() != null) {
+            queryParams.add("include-webresources", request.includeWebresources().toString());
+        }
+        if (request.includeCollaborators() != null) {
+            queryParams.add("include-collaborators", request.includeCollaborators().toString());
+        }
+        
+        String uri = UriComponentsBuilder.fromPath(API_PATH + "/pages/" + pageId)
+            .queryParams(queryParams)
+            .toUriString();
+            
+        logger.debug("Making request to: {}", uri);
+        
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(PageDetailed.class)
+            .doOnSuccess(page -> logger.debug("Successfully retrieved page: {}", 
+                page != null ? page.title() : "null"))
+            .doOnError(error -> logger.error("Error getting page {}", pageId, error));
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluenceSearchClient.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluenceSearchClient.java
@@ -1,0 +1,75 @@
+package io.github.greenstevester.confluence_mcp_svr.client;
+
+import io.github.greenstevester.confluence_mcp_svr.model.search.SearchRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.search.SearchResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * Client for interacting with Confluence Search API
+ */
+@Component
+public class ConfluenceSearchClient {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSearchClient.class);
+    private static final String API_PATH = "/wiki/rest/api";
+    
+    private final WebClient webClient;
+    
+    public ConfluenceSearchClient(WebClient confluenceWebClient) {
+        this.webClient = confluenceWebClient;
+    }
+    
+    /**
+     * Search content using CQL (Confluence Query Language)
+     */
+    public Mono<SearchResponse> search(SearchRequest request) {
+        logger.debug("Searching with CQL: {}", request.cql());
+        
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        
+        queryParams.add("cql", request.cql());
+        
+        if (request.cqlcontext() != null) {
+            queryParams.add("cqlcontext", request.cqlcontext());
+        }
+        if (request.cursor() != null) {
+            queryParams.add("cursor", request.cursor());
+        }
+        if (request.limit() != null) {
+            queryParams.add("limit", request.limit().toString());
+        }
+        if (request.start() != null) {
+            queryParams.add("start", request.start().toString());
+        }
+        if (request.includeArchivedSpaces() != null) {
+            queryParams.add("includeArchivedSpaces", request.includeArchivedSpaces().toString());
+        }
+        if (request.excludeCurrentSpaces() != null) {
+            queryParams.add("excludeCurrentSpaces", request.excludeCurrentSpaces().toString());
+        }
+        if (request.excerpt() != null) {
+            queryParams.add("excerpt", request.excerpt().getValue());
+        }
+        
+        String uri = UriComponentsBuilder.fromPath(API_PATH + "/search")
+            .queryParams(queryParams)
+            .toUriString();
+            
+        logger.debug("Making search request to: {}", uri);
+        
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(SearchResponse.class)
+            .doOnSuccess(response -> logger.debug("Search completed with {} results", 
+                response != null ? response.results().size() : 0))
+            .doOnError(error -> logger.error("Error during search", error));
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluenceSpacesClient.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/client/ConfluenceSpacesClient.java
@@ -1,0 +1,97 @@
+package io.github.greenstevester.confluence_mcp_svr.client;
+
+import io.github.greenstevester.confluence_mcp_svr.model.common.PaginatedResponse;
+import io.github.greenstevester.confluence_mcp_svr.model.space.Space;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Client for interacting with Confluence Spaces API
+ */
+@Component
+public class ConfluenceSpacesClient {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSpacesClient.class);
+    private static final String API_PATH = "/wiki/api/v2";
+    
+    private final WebClient webClient;
+    
+    public ConfluenceSpacesClient(WebClient confluenceWebClient) {
+        this.webClient = confluenceWebClient;
+    }
+    
+    /**
+     * List spaces from Confluence
+     */
+    public Mono<PaginatedResponse<Space>> listSpaces(List<String> ids, 
+                                                    List<String> keys, 
+                                                    List<String> types, 
+                                                    List<String> statuses,
+                                                    String cursor,
+                                                    Integer limit) {
+        logger.debug("Listing spaces with parameters");
+        
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        
+        if (ids != null && !ids.isEmpty()) {
+            queryParams.put("ids", ids);
+        }
+        if (keys != null && !keys.isEmpty()) {
+            queryParams.put("keys", keys);
+        }
+        if (types != null && !types.isEmpty()) {
+            queryParams.put("types", types);
+        }
+        if (statuses != null && !statuses.isEmpty()) {
+            queryParams.put("statuses", statuses);
+        }
+        if (cursor != null) {
+            queryParams.add("cursor", cursor);
+        }
+        if (limit != null) {
+            queryParams.add("limit", limit.toString());
+        }
+        
+        String uri = UriComponentsBuilder.fromPath(API_PATH + "/spaces")
+            .queryParams(queryParams)
+            .toUriString();
+            
+        logger.debug("Making request to: {}", uri);
+        
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<PaginatedResponse<Space>>() {})
+            .doOnSuccess(response -> logger.debug("Successfully retrieved {} spaces", 
+                response != null ? response.results().size() : 0))
+            .doOnError(error -> logger.error("Error listing spaces", error));
+    }
+    
+    /**
+     * Get a specific space by ID
+     */
+    public Mono<Space> getSpace(String spaceId) {
+        logger.debug("Getting space with ID: {}", spaceId);
+        
+        String uri = API_PATH + "/spaces/" + spaceId;
+        
+        logger.debug("Making request to: {}", uri);
+        
+        return webClient.get()
+            .uri(uri)
+            .retrieve()
+            .bodyToMono(Space.class)
+            .doOnSuccess(space -> logger.debug("Successfully retrieved space: {}", 
+                space != null ? space.name() : "null"))
+            .doOnError(error -> logger.error("Error getting space {}", spaceId, error));
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/ConfluenceProperties.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/ConfluenceProperties.java
@@ -1,0 +1,40 @@
+package io.github.greenstevester.confluence_mcp_svr.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.Duration;
+
+/**
+ * Configuration properties for Confluence API integration
+ */
+@ConfigurationProperties(prefix = "confluence")
+@Validated
+public record ConfluenceProperties(
+    @Valid @NotNull Api api,
+    @Valid @NotNull Defaults defaults
+) {
+    
+    public record Api(
+        @NotBlank String baseUrl,
+        @NotBlank String username,
+        @NotBlank String token,
+        @NotNull Duration timeout,
+        @Positive int maxConnections,
+        @Positive int retryAttempts
+    ) {}
+    
+    public record Defaults(
+        @Positive int pageSize,
+        @NotBlank String bodyFormat,
+        boolean includeLabels,
+        boolean includeProperties,
+        boolean includeWebresources,
+        boolean includeCollaborators,
+        boolean includeVersion
+    ) {}
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/McpServerProperties.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/McpServerProperties.java
@@ -1,0 +1,17 @@
+package io.github.greenstevester.confluence_mcp_svr.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Configuration properties for MCP server metadata
+ */
+@ConfigurationProperties(prefix = "mcp.server")
+@Validated
+public record McpServerProperties(
+    @NotBlank String name,
+    @NotBlank String version,
+    @NotBlank String description
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/WebClientConfiguration.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/config/WebClientConfiguration.java
@@ -1,0 +1,33 @@
+package io.github.greenstevester.confluence_mcp_svr.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Configuration for WebClient used to communicate with Confluence API
+ */
+@Configuration
+@EnableConfigurationProperties({ConfluenceProperties.class, McpServerProperties.class})
+public class WebClientConfiguration {
+
+    @Bean
+    public WebClient confluenceWebClient(ConfluenceProperties confluenceProperties) {
+        String credentials = confluenceProperties.api().username() + ":" + confluenceProperties.api().token();
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        
+        return WebClient.builder()
+            .baseUrl(confluenceProperties.api().baseUrl())
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+            .defaultHeader(HttpHeaders.USER_AGENT, "MCP-Confluence-Server/2.0.1")
+            .build();
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/exception/ConfluenceAuthenticationException.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/exception/ConfluenceAuthenticationException.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.exception;
+
+/**
+ * Exception thrown when Confluence authentication fails
+ */
+public class ConfluenceAuthenticationException extends ConfluenceException {
+    
+    public ConfluenceAuthenticationException(String message) {
+        super(message);
+    }
+    
+    public ConfluenceAuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/exception/ConfluenceException.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/exception/ConfluenceException.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.exception;
+
+/**
+ * Base exception for Confluence-related errors
+ */
+public class ConfluenceException extends RuntimeException {
+    
+    public ConfluenceException(String message) {
+        super(message);
+    }
+    
+    public ConfluenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/ContentRepresentation.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/ContentRepresentation.java
@@ -1,0 +1,12 @@
+package io.github.greenstevester.confluence_mcp_svr.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents content in a specific format (storage, view, etc.)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ContentRepresentation(
+    String value,
+    String representation
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/Label.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/Label.java
@@ -1,0 +1,13 @@
+package io.github.greenstevester.confluence_mcp_svr.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents a Confluence label
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Label(
+    String id,
+    String name,
+    String prefix
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/PaginatedResponse.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/PaginatedResponse.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Generic paginated response structure for Confluence API
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PaginatedResponse<T>(
+    List<T> results,
+    @JsonProperty("_links") ResponseLinks links
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/ResponseLinks.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/ResponseLinks.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents response links in Confluence API responses
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ResponseLinks(
+    String next,
+    String base,
+    String self,
+    String context
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/Version.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/common/Version.java
@@ -1,0 +1,17 @@
+package io.github.greenstevester.confluence_mcp_svr.model.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a version of content in Confluence
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Version(
+    LocalDateTime createdAt,
+    String message,
+    int number,
+    Boolean minorEdit,
+    String authorId
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/dto/GetPageRequest.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/dto/GetPageRequest.java
@@ -1,0 +1,26 @@
+package io.github.greenstevester.confluence_mcp_svr.model.dto;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.BodyFormat;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ContentStatus;
+
+import java.util.List;
+
+/**
+ * Request DTO for getting a specific page
+ */
+public record GetPageRequest(
+    String pageId,
+    BodyFormat bodyFormat,
+    Boolean getDraft,
+    List<ContentStatus> status,
+    Integer version,
+    Boolean includeLabels,
+    Boolean includeProperties,
+    Boolean includeOperations,
+    Boolean includeLikes,
+    Boolean includeVersions,
+    Boolean includeVersion,
+    Boolean includeFavoritedByCurrentUserStatus,
+    Boolean includeWebresources,
+    Boolean includeCollaborators
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/dto/ListPagesRequest.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/dto/ListPagesRequest.java
@@ -1,0 +1,23 @@
+package io.github.greenstevester.confluence_mcp_svr.model.dto;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.BodyFormat;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ContentStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.PageSortOrder;
+
+import java.util.List;
+
+/**
+ * Request DTO for listing pages
+ */
+public record ListPagesRequest(
+    List<String> id,
+    List<String> spaceId,
+    String parentId,
+    PageSortOrder sort,
+    List<ContentStatus> status,
+    String title,
+    String query,
+    BodyFormat bodyFormat,
+    String cursor,
+    Integer limit
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/BodyFormat.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/BodyFormat.java
@@ -1,0 +1,36 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Body format enumeration for Confluence content
+ */
+public enum BodyFormat {
+    STORAGE("storage"),
+    ATLAS_DOC_FORMAT("atlas_doc_format"),
+    VIEW("view"),
+    EXPORT_VIEW("export_view"),
+    ANONYMOUS_EXPORT_VIEW("anonymous_export_view"),
+    STYLED_VIEW("styled_view"),
+    EDITOR("editor");
+
+    private final String value;
+
+    BodyFormat(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static BodyFormat fromValue(String value) {
+        for (BodyFormat format : values()) {
+            if (format.value.equals(value)) {
+                return format;
+            }
+        }
+        throw new IllegalArgumentException("Unknown body format: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/ContentStatus.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/ContentStatus.java
@@ -1,0 +1,35 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Page status enumeration for Confluence content
+ */
+public enum ContentStatus {
+    CURRENT("current"),
+    TRASHED("trashed"),
+    DELETED("deleted"),
+    DRAFT("draft"),
+    ARCHIVED("archived"),
+    HISTORICAL("historical");
+
+    private final String value;
+
+    ContentStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static ContentStatus fromValue(String value) {
+        for (ContentStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown content status: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/ExcerptStrategy.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/ExcerptStrategy.java
@@ -1,0 +1,34 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Excerpt strategy enumeration for search results
+ */
+public enum ExcerptStrategy {
+    HIGHLIGHT("highlight"),
+    INDEXED("indexed"),
+    NONE("none"),
+    HIGHLIGHT_UNESCAPED("highlight_unescaped"),
+    INDEXED_UNESCAPED("indexed_unescaped");
+
+    private final String value;
+
+    ExcerptStrategy(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static ExcerptStrategy fromValue(String value) {
+        for (ExcerptStrategy strategy : values()) {
+            if (strategy.value.equals(value)) {
+                return strategy;
+            }
+        }
+        throw new IllegalArgumentException("Unknown excerpt strategy: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/PageSortOrder.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/PageSortOrder.java
@@ -1,0 +1,37 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Sort order enumeration for Confluence pages
+ */
+public enum PageSortOrder {
+    ID("id"),
+    ID_DESC("-id"),
+    CREATED_DATE("created-date"),
+    CREATED_DATE_DESC("-created-date"),
+    MODIFIED_DATE("modified-date"),
+    MODIFIED_DATE_DESC("-modified-date"),
+    TITLE("title"),
+    TITLE_DESC("-title");
+
+    private final String value;
+
+    PageSortOrder(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static PageSortOrder fromValue(String value) {
+        for (PageSortOrder order : values()) {
+            if (order.value.equals(value)) {
+                return order;
+            }
+        }
+        throw new IllegalArgumentException("Unknown sort order: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/SpaceStatus.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/SpaceStatus.java
@@ -1,0 +1,31 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Space status enumeration for Confluence spaces
+ */
+public enum SpaceStatus {
+    CURRENT("current"),
+    ARCHIVED("archived");
+
+    private final String value;
+
+    SpaceStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static SpaceStatus fromValue(String value) {
+        for (SpaceStatus status : values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown space status: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/SpaceType.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/enums/SpaceType.java
@@ -1,0 +1,33 @@
+package io.github.greenstevester.confluence_mcp_svr.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Space type enumeration for Confluence spaces
+ */
+public enum SpaceType {
+    GLOBAL("global"),
+    PERSONAL("personal"),
+    COLLABORATION("collaboration"),
+    KNOWLEDGE_BASE("knowledge_base");
+
+    private final String value;
+
+    SpaceType(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static SpaceType fromValue(String value) {
+        for (SpaceType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown space type: " + value);
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/Page.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/Page.java
@@ -1,0 +1,30 @@
+package io.github.greenstevester.confluence_mcp_svr.model.page;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ResponseLinks;
+import io.github.greenstevester.confluence_mcp_svr.model.common.Version;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ContentStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a Confluence page
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Page(
+    String id,
+    ContentStatus status,
+    String title,
+    String spaceId,
+    String parentId,
+    String parentType,
+    Integer position,
+    String authorId,
+    String ownerId,
+    String lastOwnerId,
+    LocalDateTime createdAt,
+    Version version,
+    PageBody body,
+    @JsonProperty("_links") ResponseLinks links
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/PageBody.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/PageBody.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.model.page;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ContentRepresentation;
+
+/**
+ * Represents the body content of a Confluence page in different formats
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PageBody(
+    ContentRepresentation storage,
+    @JsonProperty("atlas_doc_format") ContentRepresentation atlasDocFormat,
+    ContentRepresentation view
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/PageDetailed.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/page/PageDetailed.java
@@ -1,0 +1,22 @@
+package io.github.greenstevester.confluence_mcp_svr.model.page;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.github.greenstevester.confluence_mcp_svr.model.common.Label;
+import io.github.greenstevester.confluence_mcp_svr.model.common.Version;
+
+import java.util.List;
+
+/**
+ * Extended page object with additional optional fields
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PageDetailed(
+    String id,
+    String title,
+    String spaceId,
+    String parentId,
+    PageBody body,
+    List<Label> labels,
+    List<Version> versions,
+    Boolean isFavoritedByCurrentUser
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchRequest.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchRequest.java
@@ -1,0 +1,17 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ExcerptStrategy;
+
+/**
+ * Search request parameters for Confluence CQL search
+ */
+public record SearchRequest(
+    String cql,
+    String cqlcontext,
+    String cursor,
+    Integer limit,
+    Integer start,
+    Boolean includeArchivedSpaces,
+    Boolean excludeCurrentSpaces,
+    ExcerptStrategy excerpt
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResponse.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResponse.java
@@ -1,0 +1,22 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ResponseLinks;
+
+import java.util.List;
+
+/**
+ * Response from Confluence search API
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResponse(
+    List<SearchResult> results,
+    Integer limit,
+    Integer size,
+    Integer start,
+    Integer totalSize,
+    String cqlQuery,
+    Integer searchDuration,
+    @JsonProperty("_links") ResponseLinks links
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResult.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResult.java
@@ -1,0 +1,25 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Represents a search result from Confluence
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResult(
+    SearchResultContent content,
+    String title,
+    String excerpt,
+    String url,
+    String entityType,
+    String iconCssClass,
+    LocalDateTime lastModified,
+    String friendlyLastModified,
+    Double score,
+    SearchResultContainer resultGlobalContainer,
+    List<Object> breadcrumbs
+) {}
+

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultContainer.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultContainer.java
@@ -1,0 +1,12 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents container information in search results
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultContainer(
+    String title,
+    String displayUrl
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultContent.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultContent.java
@@ -1,0 +1,18 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents search result content details
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultContent(
+    String id,
+    String type,
+    String status,
+    String title,
+    SearchResultSpace space,
+    SearchResultHistory history,
+    SearchResultVersion version,
+    SearchResultLinks links
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultHistory.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultHistory.java
@@ -1,0 +1,11 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents history information in search results
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultHistory(
+    Boolean latest
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultLinks.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultLinks.java
@@ -1,0 +1,13 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents links in search results
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultLinks(
+    String webui,
+    String self,
+    String tinyui
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultSpace.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultSpace.java
@@ -1,0 +1,14 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents space information in search results
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultSpace(
+    String key,
+    String name,
+    String type,
+    String status
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultVersion.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/search/SearchResultVersion.java
@@ -1,0 +1,15 @@
+package io.github.greenstevester.confluence_mcp_svr.model.search;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents version information in search results
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SearchResultVersion(
+    LocalDateTime when,
+    Integer number,
+    Boolean minorEdit
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/Space.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/Space.java
@@ -1,0 +1,29 @@
+package io.github.greenstevester.confluence_mcp_svr.model.space;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ContentRepresentation;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ResponseLinks;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceType;
+
+import java.time.LocalDateTime;
+
+/**
+ * Represents a Confluence space
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Space(
+    String id,
+    String key,
+    String name,
+    SpaceType type,
+    SpaceStatus status,
+    String authorId,
+    LocalDateTime createdAt,
+    String homepageId,
+    SpaceDescription description,
+    SpaceIcon icon,
+    @JsonProperty("_links") ResponseLinks links
+) {}
+

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/SpaceDescription.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/SpaceDescription.java
@@ -1,0 +1,13 @@
+package io.github.greenstevester.confluence_mcp_svr.model.space;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.github.greenstevester.confluence_mcp_svr.model.common.ContentRepresentation;
+
+/**
+ * Represents space description in different formats
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SpaceDescription(
+    ContentRepresentation plain,
+    ContentRepresentation view
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/SpaceIcon.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/model/space/SpaceIcon.java
@@ -1,0 +1,12 @@
+package io.github.greenstevester.confluence_mcp_svr.model.space;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Represents space icon information
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SpaceIcon(
+    String path,
+    String apiDownloadLink
+) {}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluencePagesService.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluencePagesService.java
@@ -1,0 +1,233 @@
+package io.github.greenstevester.confluence_mcp_svr.service;
+
+import io.github.greenstevester.confluence_mcp_svr.client.ConfluencePagesClient;
+import io.github.greenstevester.confluence_mcp_svr.config.ConfluenceProperties;
+import io.github.greenstevester.confluence_mcp_svr.model.common.PaginatedResponse;
+import io.github.greenstevester.confluence_mcp_svr.model.dto.GetPageRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.dto.ListPagesRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.BodyFormat;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ContentStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.PageSortOrder;
+import io.github.greenstevester.confluence_mcp_svr.model.page.Page;
+import io.github.greenstevester.confluence_mcp_svr.model.page.PageDetailed;
+import io.github.greenstevester.confluence_mcp_svr.util.HtmlToMarkdownConverter;
+import io.github.greenstevester.confluence_mcp_svr.util.MarkdownFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for managing Confluence pages operations
+ */
+@Service
+public class ConfluencePagesService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluencePagesService.class);
+    
+    private final ConfluencePagesClient pagesClient;
+    private final ConfluenceProperties confluenceProperties;
+    private final MarkdownFormatter markdownFormatter;
+    private final HtmlToMarkdownConverter htmlToMarkdownConverter;
+    
+    public ConfluencePagesService(
+            ConfluencePagesClient pagesClient,
+            ConfluenceProperties confluenceProperties,
+            MarkdownFormatter markdownFormatter,
+            HtmlToMarkdownConverter htmlToMarkdownConverter) {
+        this.pagesClient = pagesClient;
+        this.confluenceProperties = confluenceProperties;
+        this.markdownFormatter = markdownFormatter;
+        this.htmlToMarkdownConverter = htmlToMarkdownConverter;
+    }
+    
+    /**
+     * List pages with optional filtering
+     */
+    public Mono<String> listPages(
+            List<String> spaceIds,
+            String query,
+            List<ContentStatus> statuses,
+            PageSortOrder sort,
+            Integer limit,
+            String cursor) {
+        
+        logger.debug("Listing pages with spaceIds: {}, query: {}", spaceIds, query);
+        
+        // Build request with defaults
+        ListPagesRequest request = new ListPagesRequest(
+            null, // id
+            spaceIds,
+            null, // parentId
+            sort != null ? sort : PageSortOrder.MODIFIED_DATE_DESC,
+            statuses != null ? statuses : List.of(ContentStatus.CURRENT),
+            null, // title
+            query,
+            BodyFormat.STORAGE,
+            cursor,
+            limit != null ? limit : confluenceProperties.defaults().pageSize()
+        );
+        
+        return pagesClient.listPages(request)
+            .map(this::formatPagesList)
+            .doOnSuccess(result -> logger.debug("Formatted pages list response"))
+            .doOnError(error -> logger.error("Error listing pages", error));
+    }
+    
+    /**
+     * Get detailed information about a specific page
+     */
+    public Mono<String> getPage(String pageId) {
+        logger.debug("Getting page details for ID: {}", pageId);
+        
+        GetPageRequest request = new GetPageRequest(
+            pageId,
+            BodyFormat.STORAGE,
+            false, // getDraft
+            List.of(ContentStatus.CURRENT),
+            null, // version
+            confluenceProperties.defaults().includeLabels(),
+            confluenceProperties.defaults().includeProperties(),
+            false, // includeOperations
+            false, // includeLikes
+            false, // includeVersions
+            confluenceProperties.defaults().includeVersion(),
+            false, // includeFavoritedByCurrentUserStatus
+            confluenceProperties.defaults().includeWebresources(),
+            confluenceProperties.defaults().includeCollaborators()
+        );
+        
+        return pagesClient.getPage(pageId, request)
+            .map(this::formatPageDetails)
+            .doOnSuccess(result -> logger.debug("Formatted page details response"))
+            .doOnError(error -> logger.error("Error getting page {}", pageId, error));
+    }
+    
+    /**
+     * Format a list of pages for display
+     */
+    private String formatPagesList(PaginatedResponse<Page> pagesResponse) {
+        List<Page> pages = pagesResponse.results();
+        
+        if (pages == null || pages.isEmpty()) {
+            return "No Confluence pages found matching your criteria.";
+        }
+        
+        StringBuilder result = new StringBuilder();
+        result.append(markdownFormatter.formatHeading("Confluence Pages", 1))
+              .append("\n\n");
+        
+        for (int i = 0; i < pages.size(); i++) {
+            Page page = pages.get(i);
+            result.append(formatPageListItem(page, i + 1));
+            
+            if (i < pages.size() - 1) {
+                result.append("\n\n").append(markdownFormatter.formatSeparator());
+            }
+            result.append("\n\n");
+        }
+        
+        // Add pagination info if available
+        if (pagesResponse.links() != null && pagesResponse.links().next() != null) {
+            result.append(markdownFormatter.formatItalic("More pages available. Use cursor for pagination."))
+                  .append("\n\n");
+        }
+        
+        result.append(markdownFormatter.formatItalic(
+            "Page information retrieved at " + markdownFormatter.formatDate(LocalDateTime.now())));
+        
+        return result.toString();
+    }
+    
+    /**
+     * Format a single page item for list display
+     */
+    private String formatPageListItem(Page page, int index) {
+        StringBuilder result = new StringBuilder();
+        
+        result.append(markdownFormatter.formatHeading(page.title(), 2))
+              .append("\n\n");
+        
+        String baseUrl = confluenceProperties.api().baseUrl();
+        String pageUrl = baseUrl + "/pages/viewpage.action?pageId=" + page.id();
+        
+        Map<String, Object> properties = Map.of(
+            "ID", page.id(),
+            "Status", page.status().getValue(),
+            "Space ID", page.spaceId() != null ? page.spaceId() : "N/A",
+            "Title", page.title(),
+            "Created", page.createdAt() != null ? markdownFormatter.formatDate(page.createdAt()) : "Not available",
+            "Author", page.authorId() != null ? page.authorId() : "Unknown",
+            "Version", page.version() != null ? page.version().number() : "N/A",
+            "URL", markdownFormatter.formatUrl(pageUrl, page.title())
+        );
+        
+        result.append(markdownFormatter.formatBulletList(properties, key -> key));
+        
+        return result.toString();
+    }
+    
+    /**
+     * Format detailed page information for display
+     */
+    private String formatPageDetails(PageDetailed pageData) {
+        StringBuilder result = new StringBuilder();
+        
+        // Page title and overview
+        result.append(markdownFormatter.formatHeading("Confluence Page: " + pageData.title(), 1))
+              .append("\n\n");
+        
+        String baseUrl = confluenceProperties.api().baseUrl();
+        String overview = String.format("A page in space `%s`", pageData.spaceId());
+        result.append(markdownFormatter.formatBlockquote(overview))
+              .append("\n\n");
+        
+        // Basic Information
+        result.append(markdownFormatter.formatHeading("Basic Information", 2))
+              .append("\n\n");
+        
+        Map<String, Object> basicInfo = Map.of(
+            "ID", pageData.id(),
+            "Title", pageData.title(),
+            "Space ID", pageData.spaceId() != null ? pageData.spaceId() : "N/A",
+            "Parent ID", pageData.parentId() != null ? pageData.parentId() : "None"
+        );
+        
+        result.append(markdownFormatter.formatBulletList(basicInfo, key -> key))
+              .append("\n\n");
+        
+        // Page Content
+        if (pageData.body() != null && pageData.body().storage() != null) {
+            result.append(markdownFormatter.formatHeading("Page Content", 2))
+                  .append("\n\n");
+            
+            String htmlContent = pageData.body().storage().value();
+            String markdownContent = htmlToMarkdownConverter.convert(htmlContent);
+            
+            result.append(markdownContent)
+                  .append("\n\n");
+        }
+        
+        // Labels
+        if (pageData.labels() != null && !pageData.labels().isEmpty()) {
+            result.append(markdownFormatter.formatHeading("Labels", 2))
+                  .append("\n\n");
+            
+            String labelList = pageData.labels().stream()
+                .map(label -> markdownFormatter.formatInlineCode(label.name()))
+                .reduce("", (acc, label) -> acc.isEmpty() ? label : acc + ", " + label);
+            
+            result.append(labelList).append("\n\n");
+        }
+        
+        // Timestamp
+        result.append(markdownFormatter.formatItalic(
+            "Page information retrieved at " + markdownFormatter.formatDate(LocalDateTime.now())));
+        
+        return result.toString();
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluenceSearchService.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluenceSearchService.java
@@ -1,0 +1,171 @@
+package io.github.greenstevester.confluence_mcp_svr.service;
+
+import io.github.greenstevester.confluence_mcp_svr.client.ConfluenceSearchClient;
+import io.github.greenstevester.confluence_mcp_svr.config.ConfluenceProperties;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ExcerptStrategy;
+import io.github.greenstevester.confluence_mcp_svr.model.search.SearchRequest;
+import io.github.greenstevester.confluence_mcp_svr.model.search.SearchResponse;
+import io.github.greenstevester.confluence_mcp_svr.model.search.SearchResult;
+import io.github.greenstevester.confluence_mcp_svr.util.MarkdownFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for Confluence search operations using CQL
+ */
+@Service
+public class ConfluenceSearchService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSearchService.class);
+    
+    private final ConfluenceSearchClient searchClient;
+    private final ConfluenceProperties confluenceProperties;
+    private final MarkdownFormatter markdownFormatter;
+    
+    public ConfluenceSearchService(
+            ConfluenceSearchClient searchClient,
+            ConfluenceProperties confluenceProperties,
+            MarkdownFormatter markdownFormatter) {
+        this.searchClient = searchClient;
+        this.confluenceProperties = confluenceProperties;
+        this.markdownFormatter = markdownFormatter;
+    }
+    
+    /**
+     * Search Confluence content using CQL
+     */
+    public Mono<String> search(
+            String cql,
+            String cqlContext,
+            Integer limit,
+            Integer start,
+            Boolean includeArchivedSpaces,
+            ExcerptStrategy excerpt) {
+        
+        logger.debug("Searching with CQL: {}", cql);
+        
+        SearchRequest request = new SearchRequest(
+            cql,
+            cqlContext,
+            null, // cursor
+            limit != null ? limit : confluenceProperties.defaults().pageSize(),
+            start,
+            includeArchivedSpaces,
+            false, // excludeCurrentSpaces
+            excerpt != null ? excerpt : ExcerptStrategy.HIGHLIGHT
+        );
+        
+        return searchClient.search(request)
+            .map(this::formatSearchResults)
+            .doOnSuccess(result -> logger.debug("Formatted search results"))
+            .doOnError(error -> logger.error("Error during search", error));
+    }
+    
+    /**
+     * Format search results for display
+     */
+    private String formatSearchResults(SearchResponse searchResponse) {
+        List<SearchResult> results = searchResponse.results();
+        
+        if (results == null || results.isEmpty()) {
+            return "No results found for your search query.";
+        }
+        
+        StringBuilder result = new StringBuilder();
+        
+        // Header with search info
+        result.append(markdownFormatter.formatHeading("Confluence Search Results", 1))
+              .append("\n\n");
+        
+        if (searchResponse.cqlQuery() != null) {
+            result.append(markdownFormatter.formatBold("Query: "))
+                  .append(markdownFormatter.formatInlineCode(searchResponse.cqlQuery()))
+                  .append("\n\n");
+        }
+        
+        // Search summary
+        String summary = String.format("Found %d results", searchResponse.size());
+        if (searchResponse.totalSize() != null && searchResponse.totalSize() > searchResponse.size()) {
+            summary += String.format(" (showing %d of %d total)", searchResponse.size(), searchResponse.totalSize());
+        }
+        result.append(markdownFormatter.formatBlockquote(summary))
+              .append("\n\n");
+        
+        // Format each result
+        for (int i = 0; i < results.size(); i++) {
+            SearchResult searchResult = results.get(i);
+            result.append(formatSearchResultItem(searchResult, i + 1));
+            
+            if (i < results.size() - 1) {
+                result.append("\n\n").append(markdownFormatter.formatSeparator());
+            }
+            result.append("\n\n");
+        }
+        
+        // Search metadata
+        if (searchResponse.searchDuration() != null) {
+            result.append(markdownFormatter.formatItalic(
+                String.format("Search completed in %d ms", searchResponse.searchDuration())))
+                  .append("\n");
+        }
+        
+        result.append(markdownFormatter.formatItalic(
+            "Results retrieved at " + markdownFormatter.formatDate(LocalDateTime.now())));
+        
+        return result.toString();
+    }
+    
+    /**
+     * Format a single search result item
+     */
+    private String formatSearchResultItem(SearchResult searchResult, int index) {
+        StringBuilder result = new StringBuilder();
+        
+        // Title with link
+        String title = searchResult.title() != null ? searchResult.title() : "Untitled";
+        if (searchResult.url() != null) {
+            title = markdownFormatter.formatUrl(searchResult.url(), title);
+        }
+        
+        result.append(markdownFormatter.formatHeading(title, 3))
+              .append("\n\n");
+        
+        // Content information
+        if (searchResult.content() != null) {
+            Map<String, Object> contentInfo = Map.of(
+                "Type", searchResult.content().type() != null ? searchResult.content().type() : "Unknown",
+                "Status", searchResult.content().status() != null ? searchResult.content().status() : "Unknown",
+                "Space", searchResult.content().space() != null ? 
+                    String.format("%s (%s)", searchResult.content().space().name(), searchResult.content().space().key()) : "N/A",
+                "Last Modified", searchResult.lastModified() != null ? 
+                    markdownFormatter.formatDate(searchResult.lastModified()) : "Unknown"
+            );
+            
+            result.append(markdownFormatter.formatBulletList(contentInfo, key -> key))
+                  .append("\n\n");
+        }
+        
+        // Excerpt if available
+        if (searchResult.excerpt() != null && !searchResult.excerpt().trim().isEmpty()) {
+            result.append(markdownFormatter.formatHeading("Excerpt", 4))
+                  .append("\n\n");
+            result.append(markdownFormatter.formatBlockquote(searchResult.excerpt()))
+                  .append("\n\n");
+        }
+        
+        // Score if available
+        if (searchResult.score() != null) {
+            result.append(markdownFormatter.formatBold("Relevance Score: "))
+                  .append(String.format("%.2f", searchResult.score()))
+                  .append("\n");
+        }
+        
+        return result.toString();
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluenceSpacesService.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/service/ConfluenceSpacesService.java
@@ -1,0 +1,224 @@
+package io.github.greenstevester.confluence_mcp_svr.service;
+
+import io.github.greenstevester.confluence_mcp_svr.client.ConfluenceSpacesClient;
+import io.github.greenstevester.confluence_mcp_svr.config.ConfluenceProperties;
+import io.github.greenstevester.confluence_mcp_svr.model.common.PaginatedResponse;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceType;
+import io.github.greenstevester.confluence_mcp_svr.model.space.Space;
+import io.github.greenstevester.confluence_mcp_svr.util.MarkdownFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Service for Confluence spaces operations
+ */
+@Service
+public class ConfluenceSpacesService {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSpacesService.class);
+    
+    private final ConfluenceSpacesClient spacesClient;
+    private final ConfluenceProperties confluenceProperties;
+    private final MarkdownFormatter markdownFormatter;
+    
+    public ConfluenceSpacesService(
+            ConfluenceSpacesClient spacesClient,
+            ConfluenceProperties confluenceProperties,
+            MarkdownFormatter markdownFormatter) {
+        this.spacesClient = spacesClient;
+        this.confluenceProperties = confluenceProperties;
+        this.markdownFormatter = markdownFormatter;
+    }
+    
+    /**
+     * List spaces with optional filtering
+     */
+    public Mono<String> listSpaces(
+            List<String> ids,
+            List<String> keys,
+            List<SpaceType> types,
+            List<SpaceStatus> statuses,
+            Integer limit,
+            String cursor) {
+        
+        logger.debug("Listing spaces with ids: {}, keys: {}", ids, keys);
+        
+        List<String> typeStrings = types != null ? 
+            types.stream().map(SpaceType::getValue).collect(Collectors.toList()) : null;
+        List<String> statusStrings = statuses != null ?
+            statuses.stream().map(SpaceStatus::getValue).collect(Collectors.toList()) : null;
+        
+        return spacesClient.listSpaces(
+                ids,
+                keys,
+                typeStrings,
+                statusStrings,
+                cursor,
+                limit != null ? limit : confluenceProperties.defaults().pageSize())
+            .map(this::formatSpacesList)
+            .doOnSuccess(result -> logger.debug("Formatted spaces list response"))
+            .doOnError(error -> logger.error("Error listing spaces", error));
+    }
+    
+    /**
+     * Get detailed information about a specific space
+     */
+    public Mono<String> getSpace(String spaceId) {
+        logger.debug("Getting space details for ID: {}", spaceId);
+        
+        return spacesClient.getSpace(spaceId)
+            .map(this::formatSpaceDetails)
+            .doOnSuccess(result -> logger.debug("Formatted space details response"))
+            .doOnError(error -> logger.error("Error getting space {}", spaceId, error));
+    }
+    
+    /**
+     * Format a list of spaces for display
+     */
+    private String formatSpacesList(PaginatedResponse<Space> spacesResponse) {
+        List<Space> spaces = spacesResponse.results();
+        
+        if (spaces == null || spaces.isEmpty()) {
+            return "No Confluence spaces found matching your criteria.";
+        }
+        
+        StringBuilder result = new StringBuilder();
+        result.append(markdownFormatter.formatHeading("Confluence Spaces", 1))
+              .append("\n\n");
+        
+        for (int i = 0; i < spaces.size(); i++) {
+            Space space = spaces.get(i);
+            result.append(formatSpaceListItem(space, i + 1));
+            
+            if (i < spaces.size() - 1) {
+                result.append("\n\n").append(markdownFormatter.formatSeparator());
+            }
+            result.append("\n\n");
+        }
+        
+        // Add pagination info if available
+        if (spacesResponse.links() != null && spacesResponse.links().next() != null) {
+            result.append(markdownFormatter.formatItalic("More spaces available. Use cursor for pagination."))
+                  .append("\n\n");
+        }
+        
+        result.append(markdownFormatter.formatItalic(
+            "Space information retrieved at " + markdownFormatter.formatDate(LocalDateTime.now())));
+        
+        return result.toString();
+    }
+    
+    /**
+     * Format a single space item for list display
+     */
+    private String formatSpaceListItem(Space space, int index) {
+        StringBuilder result = new StringBuilder();
+        
+        result.append(markdownFormatter.formatHeading(space.name(), 2))
+              .append("\n\n");
+        
+        String baseUrl = confluenceProperties.api().baseUrl();
+        String spaceUrl = baseUrl + "/spaces/" + space.key();
+        
+        Map<String, Object> properties = Map.of(
+            "ID", space.id(),
+            "Key", markdownFormatter.formatInlineCode(space.key()),
+            "Type", space.type().getValue(),
+            "Status", space.status().getValue(),
+            "Created", space.createdAt() != null ? markdownFormatter.formatDate(space.createdAt()) : "Not available",
+            "Author", space.authorId() != null ? space.authorId() : "Unknown",
+            "Homepage ID", space.homepageId() != null ? space.homepageId() : "N/A",
+            "URL", markdownFormatter.formatUrl(spaceUrl, space.name())
+        );
+        
+        result.append(markdownFormatter.formatBulletList(properties, key -> key));
+        
+        // Add description if available
+        if (space.description() != null && space.description().plain() != null) {
+            result.append("\n\n")
+                  .append(markdownFormatter.formatHeading("Description", 4))
+                  .append("\n\n")
+                  .append(space.description().plain().value());
+        }
+        
+        return result.toString();
+    }
+    
+    /**
+     * Format detailed space information for display
+     */
+    private String formatSpaceDetails(Space space) {
+        StringBuilder result = new StringBuilder();
+        
+        // Space title and overview
+        result.append(markdownFormatter.formatHeading("Confluence Space: " + space.name(), 1))
+              .append("\n\n");
+        
+        String overview = String.format("A %s space with key `%s` and status `%s`",
+            space.type().getValue(), space.key(), space.status().getValue());
+        result.append(markdownFormatter.formatBlockquote(overview))
+              .append("\n\n");
+        
+        // Basic Information
+        result.append(markdownFormatter.formatHeading("Basic Information", 2))
+              .append("\n\n");
+        
+        Map<String, Object> basicInfo = Map.of(
+            "ID", space.id(),
+            "Name", space.name(),
+            "Key", markdownFormatter.formatInlineCode(space.key()),
+            "Type", space.type().getValue(),
+            "Status", space.status().getValue(),
+            "Created", space.createdAt() != null ? markdownFormatter.formatDate(space.createdAt()) : "Not available",
+            "Author ID", space.authorId() != null ? space.authorId() : "Unknown",
+            "Homepage ID", space.homepageId() != null ? space.homepageId() : "N/A"
+        );
+        
+        result.append(markdownFormatter.formatBulletList(basicInfo, key -> key))
+              .append("\n\n");
+        
+        // Description
+        if (space.description() != null) {
+            result.append(markdownFormatter.formatHeading("Description", 2))
+                  .append("\n\n");
+            
+            if (space.description().plain() != null && space.description().plain().value() != null) {
+                result.append(space.description().plain().value())
+                      .append("\n\n");
+            } else {
+                result.append("No description available.\n\n");
+            }
+        }
+        
+        // Space Links
+        if (space.links() != null) {
+            String baseUrl = confluenceProperties.api().baseUrl();
+            String spaceUrl = baseUrl + "/spaces/" + space.key();
+            
+            result.append(markdownFormatter.formatHeading("Links", 2))
+                  .append("\n\n");
+            
+            Map<String, Object> links = Map.of(
+                "Space URL", markdownFormatter.formatUrl(spaceUrl, "View Space"),
+                "Base URL", space.links().base() != null ? space.links().base() : "N/A"
+            );
+            
+            result.append(markdownFormatter.formatBulletList(links, key -> key))
+                  .append("\n\n");
+        }
+        
+        // Timestamp
+        result.append(markdownFormatter.formatItalic(
+            "Space information retrieved at " + markdownFormatter.formatDate(LocalDateTime.now())));
+        
+        return result.toString();
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluencePagesTools.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluencePagesTools.java
@@ -1,0 +1,82 @@
+package io.github.greenstevester.confluence_mcp_svr.tool;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ContentStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.PageSortOrder;
+import io.github.greenstevester.confluence_mcp_svr.service.ConfluencePagesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+// import org.springframework.ai.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * MCP Tools for Confluence Pages operations
+ */
+@Service
+public class ConfluencePagesTools {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluencePagesTools.class);
+    
+    private final ConfluencePagesService pagesService;
+    
+    public ConfluencePagesTools(ConfluencePagesService pagesService) {
+        this.pagesService = pagesService;
+    }
+    
+    /**
+     * List Confluence pages with optional filtering
+     */
+    public String listPages(ListPagesRequest request) {
+        logger.debug("list_pages tool called with: {}", request);
+        
+        try {
+            return pagesService.listPages(
+                request.spaceIds(),
+                request.query(),
+                request.statuses(),
+                request.sort(),
+                request.limit(),
+                request.cursor()
+            ).block(); // Block for synchronous tool execution
+            
+        } catch (Exception e) {
+            logger.error("Error in list_pages tool", e);
+            return "Error listing pages: " + e.getMessage();
+        }
+    }
+    
+    /**
+     * Get detailed information about a specific Confluence page
+     */
+    public String getPage(GetPageRequest request) {
+        logger.debug("get_page tool called with: {}", request);
+        
+        try {
+            return pagesService.getPage(request.pageId()).block(); // Block for synchronous tool execution
+            
+        } catch (Exception e) {
+            logger.error("Error in get_page tool", e);
+            return "Error getting page: " + e.getMessage();
+        }
+    }
+    
+    /**
+     * Request object for list_pages tool
+     */
+    public record ListPagesRequest(
+        List<String> spaceIds,
+        String query,
+        List<ContentStatus> statuses,
+        PageSortOrder sort,
+        Integer limit,
+        String cursor
+    ) {}
+    
+    /**
+     * Request object for get_page tool
+     */
+    public record GetPageRequest(
+        String pageId
+    ) {}
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluenceSearchTools.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluenceSearchTools.java
@@ -1,0 +1,57 @@
+package io.github.greenstevester.confluence_mcp_svr.tool;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.ExcerptStrategy;
+import io.github.greenstevester.confluence_mcp_svr.service.ConfluenceSearchService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+// import org.springframework.ai.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+/**
+ * MCP Tools for Confluence Search operations using CQL
+ */
+@Service
+public class ConfluenceSearchTools {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSearchTools.class);
+    
+    private final ConfluenceSearchService searchService;
+    
+    public ConfluenceSearchTools(ConfluenceSearchService searchService) {
+        this.searchService = searchService;
+    }
+    
+    /**
+     * Search Confluence content using CQL (Confluence Query Language)
+     */
+    public String search(SearchRequest request) {
+        logger.debug("search tool called with CQL: {}", request.cql());
+        
+        try {
+            return searchService.search(
+                request.cql(),
+                request.cqlContext(),
+                request.limit(),
+                request.start(),
+                request.includeArchivedSpaces(),
+                request.excerpt()
+            ).block(); // Block for synchronous tool execution
+            
+        } catch (Exception e) {
+            logger.error("Error in search tool", e);
+            return "Error during search: " + e.getMessage();
+        }
+    }
+    
+    /**
+     * Request object for search tool
+     */
+    public record SearchRequest(
+        String cql,
+        String cqlContext,
+        Integer limit,
+        Integer start,
+        Boolean includeArchivedSpaces,
+        ExcerptStrategy excerpt
+    ) {}
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluenceSpacesTools.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/tool/ConfluenceSpacesTools.java
@@ -1,0 +1,154 @@
+package io.github.greenstevester.confluence_mcp_svr.tool;
+
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceStatus;
+import io.github.greenstevester.confluence_mcp_svr.model.enums.SpaceType;
+import io.github.greenstevester.confluence_mcp_svr.service.ConfluenceSpacesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+// import org.springframework.ai.annotation.Tool;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * MCP Tools for Confluence Spaces operations
+ */
+@Service
+public class ConfluenceSpacesTools {
+    
+    private static final Logger logger = LoggerFactory.getLogger(ConfluenceSpacesTools.class);
+    
+    private final ConfluenceSpacesService spacesService;
+    
+    public ConfluenceSpacesTools(ConfluenceSpacesService spacesService) {
+        this.spacesService = spacesService;
+    }
+    
+    /**
+     * List Confluence spaces with optional filtering.
+     * 
+     * List Confluence spaces with optional filtering by IDs, keys, types, or status.
+     * 
+     * PURPOSE: Discover and browse available Confluence spaces. Provides space metadata 
+     * including IDs and keys needed for other operations.
+     * 
+     * WHEN TO USE:
+     * - To discover available spaces in the Confluence instance.
+     * - To find space IDs or keys for use with page tools or search.
+     * - To get an overview of spaces before drilling down to pages.
+     * - To find spaces by type (personal, team, knowledge base, etc.).
+     * - To check space status (current vs archived).
+     * 
+     * WHEN NOT TO USE:
+     * - When you already know the specific space ID/key and need details (use 'get_space').
+     * - When you need page content (use page tools).
+     * - When you need to search content (use 'search' tool).
+     * 
+     * SPACE TYPES:
+     * - GLOBAL: Organization-wide spaces
+     * - PERSONAL: Individual user spaces  
+     * - COLLABORATION: Team collaboration spaces
+     * - KNOWLEDGE_BASE: Documentation and knowledge sharing spaces
+     * 
+     * RETURNS: Formatted list of spaces including:
+     * - Space ID (numeric) and key (string identifier)
+     * - Name, type, and status
+     * - Creation date and author information
+     * - Description and homepage information
+     * - Direct links to spaces
+     * 
+     * EXAMPLES:
+     * - List all spaces: { }
+     * - List specific spaces by key: { "keys": ["DEV", "PROD", "DOCS"] }
+     * - List by type: { "types": ["COLLABORATION", "KNOWLEDGE_BASE"] }
+     * - List current spaces only: { "statuses": ["CURRENT"] }
+     * - Paginate results: { "limit": 10, "cursor": "some-cursor-value" }
+     * - Multiple filters: { "types": ["GLOBAL"], "statuses": ["CURRENT"], "limit": 20 }
+     * 
+     * ERRORS:
+     * - Authentication failures: Check Confluence credentials.
+     * - Permission denied: User may not have access to list spaces.
+     */
+    public String listSpaces(ListSpacesRequest request) {
+        logger.debug("list_spaces tool called with: {}", request);
+        
+        try {
+            return spacesService.listSpaces(
+                request.ids(),
+                request.keys(),
+                request.types(),
+                request.statuses(),
+                request.limit(),
+                request.cursor()
+            ).block(); // Block for synchronous tool execution
+            
+        } catch (Exception e) {
+            logger.error("Error in list_spaces tool", e);
+            return "Error listing spaces: " + e.getMessage();
+        }
+    }
+    
+    /**
+     * Get detailed information about a specific Confluence space.
+     * 
+     * Get detailed information about a specific Confluence space by its ID.
+     * 
+     * PURPOSE: Retrieve comprehensive details about a single Confluence space.
+     * 
+     * WHEN TO USE:
+     * - When you have a specific space ID and need detailed information.
+     * - When you need space metadata, description, and configuration details.
+     * - When you need to understand space structure before accessing pages.
+     * 
+     * WHEN NOT TO USE:
+     * - When you need to find spaces (use 'list_spaces' instead).
+     * - When you need page content from the space (use page tools).
+     * - When you need to search within the space (use 'search' tool).
+     * 
+     * RETURNS: Detailed space information including:
+     * - Complete space metadata (ID, key, name, type, status)
+     * - Full description and purpose
+     * - Creation and authorship information
+     * - Homepage and navigation details
+     * - Access and permission information
+     * - Direct links and URLs
+     * 
+     * EXAMPLES:
+     * - Get space details: { "spaceId": "123456" }
+     * 
+     * ERRORS:
+     * - Space not found: Verify the space ID is correct and exists.
+     * - Access denied: Check permissions for the space.
+     * - Authentication failures: Check Confluence credentials.
+     */
+    public String getSpace(GetSpaceRequest request) {
+        logger.debug("get_space tool called with: {}", request);
+        
+        try {
+            return spacesService.getSpace(request.spaceId()).block(); // Block for synchronous tool execution
+            
+        } catch (Exception e) {
+            logger.error("Error in get_space tool", e);
+            return "Error getting space: " + e.getMessage();
+        }
+    }
+    
+    /**
+     * Request object for list_spaces tool
+     */
+    public record ListSpacesRequest(
+        List<String> ids,
+        List<String> keys,
+        List<SpaceType> types,
+        List<SpaceStatus> statuses,
+        Integer limit,
+        String cursor
+    ) {}
+    
+    /**
+     * Request object for get_space tool
+     */
+    public record GetSpaceRequest(
+        String spaceId
+    ) {}
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/util/HtmlToMarkdownConverter.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/util/HtmlToMarkdownConverter.java
@@ -1,0 +1,33 @@
+package io.github.greenstevester.confluence_mcp_svr.util;
+
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility class for converting HTML content to Markdown
+ */
+@Component
+public class HtmlToMarkdownConverter {
+    
+    private final FlexmarkHtmlConverter converter;
+    
+    public HtmlToMarkdownConverter() {
+        this.converter = FlexmarkHtmlConverter.builder().build();
+    }
+    
+    /**
+     * Convert HTML content to Markdown
+     */
+    public String convert(String htmlContent) {
+        if (htmlContent == null || htmlContent.trim().isEmpty()) {
+            return "";
+        }
+        
+        try {
+            return converter.convert(htmlContent);
+        } catch (Exception e) {
+            // If conversion fails, return the original content with a warning
+            return "<!-- HTML to Markdown conversion failed -->\n" + htmlContent;
+        }
+    }
+}

--- a/src/main/java/io/github/greenstevester/confluence_mcp_svr/util/MarkdownFormatter.java
+++ b/src/main/java/io/github/greenstevester/confluence_mcp_svr/util/MarkdownFormatter.java
@@ -1,0 +1,125 @@
+package io.github.greenstevester.confluence_mcp_svr.util;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+/**
+ * Utility class for formatting content as Markdown
+ */
+@Component
+public class MarkdownFormatter {
+    
+    private static final DateTimeFormatter DEFAULT_DATE_FORMAT = 
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    
+    /**
+     * Format a heading with the specified level
+     */
+    public String formatHeading(String text, int level) {
+        if (level < 1 || level > 6) {
+            level = 1;
+        }
+        return "#".repeat(level) + " " + text;
+    }
+    
+    /**
+     * Format a URL as markdown link
+     */
+    public String formatUrl(String url, String text) {
+        if (url == null || url.trim().isEmpty()) {
+            return text != null ? text : "";
+        }
+        return "[" + (text != null ? text : url) + "](" + url + ")";
+    }
+    
+    /**
+     * Format a date using the default format
+     */
+    public String formatDate(LocalDateTime dateTime) {
+        return dateTime != null ? dateTime.format(DEFAULT_DATE_FORMAT) : "Not available";
+    }
+    
+    /**
+     * Format a separator line
+     */
+    public String formatSeparator() {
+        return "---";
+    }
+    
+    /**
+     * Format a bullet list from a map of properties
+     */
+    public String formatBulletList(Map<String, Object> properties, Function<String, String> keyMapper) {
+        return properties.entrySet().stream()
+            .map(entry -> "- **" + keyMapper.apply(entry.getKey()) + "**: " + formatValue(entry.getValue()))
+            .reduce("", (acc, line) -> acc.isEmpty() ? line : acc + "\n" + line);
+    }
+    
+    /**
+     * Format a numbered list from a collection
+     */
+    public <T> String formatNumberedList(List<T> items, Function<T, String> formatter) {
+        return IntStream.range(0, items.size())
+            .mapToObj(i -> {
+                T item = items.get(i);
+                String content = formatter.apply(item);
+                return (i + 1) + ". " + content;
+            })
+            .reduce("", (acc, line) -> acc.isEmpty() ? line : acc + "\n\n" + line);
+    }
+    
+    /**
+     * Format a code block with optional language
+     */
+    public String formatCodeBlock(String content, String language) {
+        String lang = language != null ? language : "";
+        return "```" + lang + "\n" + content + "\n```";
+    }
+    
+    /**
+     * Format an object value for display
+     */
+    private String formatValue(Object value) {
+        if (value == null) {
+            return "N/A";
+        }
+        if (value instanceof LocalDateTime) {
+            return formatDate((LocalDateTime) value);
+        }
+        return value.toString();
+    }
+    
+    /**
+     * Format a blockquote
+     */
+    public String formatBlockquote(String text) {
+        return "> " + text;
+    }
+    
+    /**
+     * Format inline code
+     */
+    public String formatInlineCode(String text) {
+        return "`" + text + "`";
+    }
+    
+    /**
+     * Format bold text
+     */
+    public String formatBold(String text) {
+        return "**" + text + "**";
+    }
+    
+    /**
+     * Format italic text
+     */
+    public String formatItalic(String text) {
+        return "*" + text + "*";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,39 @@
+# Application Configuration
 spring.application.name=confluence-mcp-svr
 server.port=8081
+
+# Logging Configuration
+logging.level.io.github.greenstevester.confluence_mcp_svr=DEBUG
+logging.level.org.springframework.ai=DEBUG
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%logger{36}] - %msg%n
+
+# Confluence API Configuration
+confluence.api.base-url=https://${ATLASSIAN_SITE_NAME}.atlassian.net
+confluence.api.username=${ATLASSIAN_USER_EMAIL:}
+confluence.api.token=${ATLASSIAN_API_TOKEN:}
+confluence.api.timeout=30s
+confluence.api.max-connections=20
+confluence.api.retry-attempts=3
+
+# MCP Server Configuration  
+mcp.server.name=mcp-server-atlassian-confluence
+mcp.server.version=2.0.1
+mcp.server.description=MCP server for Atlassian Confluence. Provides tools enabling AI systems (LLMs) to list/get spaces and pages (content formatted as Markdown) and search via CQL.
+
+# Default Configuration
+confluence.defaults.page-size=25
+confluence.defaults.body-format=storage
+confluence.defaults.include-labels=true
+confluence.defaults.include-properties=false
+confluence.defaults.include-webresources=false
+confluence.defaults.include-collaborators=false
+confluence.defaults.include-version=true
+
+# Jackson Configuration
+spring.jackson.default-property-inclusion=non_null
+spring.jackson.deserialization.fail-on-unknown-properties=false
+spring.jackson.serialization.write-dates-as-timestamps=false
+
+# Validation Configuration
+server.error.include-message=always
+server.error.include-binding-errors=always

--- a/src/test/java/io/github/greenstevester/confluence_mcp_svr/ConfluenceMcpSvrApplicationTests.java
+++ b/src/test/java/io/github/greenstevester/confluence_mcp_svr/ConfluenceMcpSvrApplicationTests.java
@@ -2,8 +2,27 @@ package io.github.greenstevester.confluence_mcp_svr;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+    "confluence.api.base-url=https://test.atlassian.net",
+    "confluence.api.username=test@example.com", 
+    "confluence.api.token=test-token",
+    "confluence.api.timeout=30s",
+    "confluence.api.max-connections=20",
+    "confluence.api.retry-attempts=3",
+    "confluence.defaults.page-size=25",
+    "confluence.defaults.body-format=storage",
+    "confluence.defaults.include-labels=true",
+    "confluence.defaults.include-properties=false",
+    "confluence.defaults.include-webresources=false",
+    "confluence.defaults.include-collaborators=false",
+    "confluence.defaults.include-version=true",
+    "mcp.server.name=test-server",
+    "mcp.server.version=2.0.1",
+    "mcp.server.description=Test server"
+})
 class ConfluenceMcpSvrApplicationTests {
 
 	@Test

--- a/todos.md
+++ b/todos.md
@@ -1,0 +1,12 @@
+# Project Todo List
+
+Last updated: 2025-08-17
+
+## In Progress
+*(No tasks currently in progress)*
+
+## Pending
+*(No pending tasks)*
+
+## Completed
+*(No completed tasks)*


### PR DESCRIPTION
Migrate from TypeScript to Java Spring Boot with comprehensive architecture:

- Add complete Java model classes for Confluence API integration
- Implement service layer with WebClient for API communication
- Create MCP tool classes for pages, search, and spaces functionality
- Add configuration management with Spring Boot properties
- Include utility classes for HTML to Markdown conversion
- Set up exception handling for API errors
- Add migration architecture documentation
- Configure Gradle build with required dependencies
- Update Java version to 21 for compatibility

This establishes the core structure for the Confluence MCP server in Java, providing a solid foundation for further development and testing.

🤖 Generated with [Claude Code](https://claude.ai/code)